### PR TITLE
Update fetchNFTs.js

### DIFF
--- a/src/utils/fetchNFTs.js
+++ b/src/utils/fetchNFTs.js
@@ -51,8 +51,8 @@ const fetchNFTs = async (owner, contractAddress, setNFTs) => {
     const data = await getAddressNFTs(owner, contractAddress)
     if (data.ownedNfts.length) {
         const NFTs = await getNFTsMetadata(data.ownedNfts)
-        let fullfilledNFTs = NFTs.filter(NFT => NFT.status == "fulfilled")
-        setNFTs(fullfilledNFTs)
+        let fulfilledNFTs = NFTs.filter(NFT => NFT.status == "fulfilled")
+        setNFTs(fulfilledNFTs)
     } else {
         setNFTs(null)
     }


### PR DESCRIPTION
Typo on lines 54 & 55, the word "fulfilled" was spelled "fullfilled".